### PR TITLE
ci: main 브랜치로의 PR을 release 브랜치에서만 허용

### DIFF
--- a/.github/workflows/validate-pr-to-main.yml
+++ b/.github/workflows/validate-pr-to-main.yml
@@ -1,0 +1,17 @@
+name: Validate PR to main
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check base branch
+        run: |
+          if [[ ! "${{ github.event.pull_request.head.ref }}" =~ ^release/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Pull requests to main must be from a release branch (e.g., release/v1.0.0)."
+            exit 1
+          fi


### PR DESCRIPTION
<!-- 위에 커밋내용 아래에 정리해주시면 됩니다. -->
### ✅작업 사항 <!-- 작업 내용 적어주세요 -->

- GitHub Actions 워크플로우를 추가하여 main 브랜치로의 PR을 제한.
- PR은 'release/vX.X.X' 형식의 브랜치에서만 허용되도록 정규식을 사용한 검증 추가.
- 브랜치 이름에 대한 패턴 검증을 포함.
***
### 🧩이슈 번호
<!-- 이슈 번호를 작성해주세요 ex) #23 -->
- #8 
